### PR TITLE
fc5d22d6: Enable DPLA audiobooks

### DIFF
--- a/.ci-local/credentials.sh
+++ b/.ci-local/credentials.sh
@@ -43,28 +43,28 @@ mkdir -p "${HOME}/.gradle" ||
 cat ".ci/credentials/APK Signing/keystore.properties" >> "${HOME}/.gradle/gradle.properties" ||
   fatal "could not read keystore properties"
 
-#CREDENTIALS_PATH=$(realpath ".ci/credentials") ||
-#  fatal "could not resolve credentials path"
-#
-#SIMPLYE_CREDENTIALS="${CREDENTIALS_PATH}/SimplyE/Android"
+CREDENTIALS_PATH=$(realpath ".ci/credentials") ||
+  fatal "could not resolve credentials path"
+
+SIMPLYE_CREDENTIALS="${CREDENTIALS_PATH}/SimplyE/Android"
 #OPENEBOOKS_CREDENTIALS="${CREDENTIALS_PATH}/OpenEbooks/Android"
-#
-#if [ ! -d "${SIMPLYE_CREDENTIALS}" ]
-#then
-#  fatal "${SIMPLYE_CREDENTIALS} does not exist, or is not a directory"
-#fi
+
+if [ ! -d "${SIMPLYE_CREDENTIALS}" ]
+then
+  fatal "${SIMPLYE_CREDENTIALS} does not exist, or is not a directory"
+fi
 #if [ ! -d "${OPENEBOOKS_CREDENTIALS}" ]
 #then
 #  fatal "${OPENEBOOKS_CREDENTIALS} does not exist, or is not a directory"
 #fi
 #
-#cat >> "${HOME}/.gradle/gradle.properties" <<EOF
+cat >> "${HOME}/.gradle/gradle.properties" <<EOF
 #org.librarysimplified.drm.enabled=true
-#
+
 #org.librarysimplified.nexus.depend=true
 #org.librarysimplified.nexus.username=${NYPL_NEXUS_USER}
 #org.librarysimplified.nexus.password=${NYPL_NEXUS_PASSWORD}
-#
+
 #org.librarysimplified.app.assets.openebooks=${OPENEBOOKS_CREDENTIALS}
-#org.librarysimplified.app.assets.simplye=${SIMPLYE_CREDENTIALS}
+org.librarysimplified.app.assets.raybooks=${SIMPLYE_CREDENTIALS}
 #EOF

--- a/simplified-app-raybooks/build.gradle
+++ b/simplified-app-raybooks/build.gradle
@@ -1,8 +1,28 @@
+import org.librarysimplified.gradle.RequiredAssetsTask
+
+// Fail the build if these assets aren't present
+//
+def requiredFiles = [:]
+requiredFiles["secrets.conf"] =
+  "9c211ae0d153c29b72baab3bfad9de6c5cecb6b39bcda8206d36a65aaca0db21"
+
 android {
   defaultConfig {
     versionName = project.version
     versionCode = calculateVersionCode(project)
     setProperty("archivesBaseName", "raybooks")
+  }
+  applicationVariants.all { variant ->
+    def finalizerTask =
+      tasks.create(name: "requiredFiles${variant.name.capitalize()}", type: RequiredAssetsTask) {
+        required = requiredFiles
+        apkFiles = variant.outputs.collect { out ->
+          out.outputFile
+        }
+      }
+    variant.assembleProvider.configure {
+      finalizedBy finalizerTask
+    }
   }
 }
 


### PR DESCRIPTION
**What's this do?**
This enables the required build logic and bits of CI script for DPLA
audiobook support.

**Why are we doing this? (w/ JIRA link if applicable)**
https://www.notion.so/lyrasis/Enable-DRM-in-Android-app-fc5d22d6bca24779b66c10a24cc3ff84

**How should this be tested? / Do these changes have associated tests?**
Try loading DPLA audio books from the LYRASIS collection.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m Tried two DPLA audio books.