### PR TITLE
Hide 'Add a Library Later' option on splash screen.

### DIFF
--- a/simplified-ui-splash/src/main/res/layout/splash_selection.xml
+++ b/simplified-ui-splash/src/main/res/layout/splash_selection.xml
@@ -40,7 +40,8 @@
     android:layout_marginTop="16dp"
     android:text="@string/selectionAlternateButton"
     android:textSize="18sp"
-    android:textStyle="bold" />
+    android:textStyle="bold"
+    android:visibility="gone" />
 
   <TextView
     android:id="@+id/selectionAlternateTitle"
@@ -48,5 +49,6 @@
     android:layout_height="wrap_content"
     android:layout_marginTop="4dp"
     android:text="@string/selectionAlternateTitle"
-    android:textAppearance="@android:style/TextAppearance.Small" />
+    android:textAppearance="@android:style/TextAppearance.Small"
+    android:visibility="gone" />
 </LinearLayout>


### PR DESCRIPTION
**What's this do?**
Hide the 'Add a Library Later' button on the splash screen.

**Why are we doing this? (w/ JIRA link if applicable)**
Fixes this Notion issue: https://www.notion.so/lyrasis/Remove-Add-a-Library-Later-option-3cefbfe86dc84594a21be8d9f43fcb77

This forces the user to choose a library, so that they're not confused by getting dropped into the "SimplyE Collection" when the app is no longer called "SimplyE". (And NYPL might not allow us to use that collection.)

**How should this be tested? / Do these changes have associated tests?**
Open the app for the first time (delete the app first, if it is already installed). The initial screen should only have the "Find Your Library" button. The "Add a Library Later" button should not appear. 

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@ray-lee ran the RayBooks app.