### PR TITLE
Fix startup crash and re-hide 'Add a Library Later' option.

### DIFF
--- a/simplified-ui-onboarding/src/main/res/layout/onboarding_start_screen.xml
+++ b/simplified-ui-onboarding/src/main/res/layout/onboarding_start_screen.xml
@@ -38,7 +38,8 @@
     android:layout_marginTop="16dp"
     android:text="@string/selectionAlternateButton"
     android:textSize="18sp"
-    android:textStyle="bold" />
+    android:textStyle="bold"
+    android:visibility="gone" />
 
   <TextView
     android:id="@+id/selectionAlternateTitle"
@@ -46,5 +47,6 @@
     android:layout_height="wrap_content"
     android:layout_marginTop="4dp"
     android:text="@string/selectionAlternateTitle"
-    android:textAppearance="@android:style/TextAppearance.Small" />
+    android:textAppearance="@android:style/TextAppearance.Small"
+    android:visibility="gone" />
 </LinearLayout>

--- a/simplified-ui-splash/src/main/res/layout/onboarding_fragment.xml
+++ b/simplified-ui-splash/src/main/res/layout/onboarding_fragment.xml
@@ -2,7 +2,7 @@
 
 <androidx.fragment.app.FragmentContainerView
   xmlns:android="http://schemas.android.com/apk/res/android"
-  android:name="org.nypl.simplified.ui.splash.OnboardingStartScreenFragment"
+  android:name="org.nypl.simplified.ui.onboarding.OnboardingStartScreenFragment"
   android:id="@+id/onboarding_fragment_container"
   android:layout_width="match_parent"
   android:layout_height="match_parent">


### PR DESCRIPTION
**What's this do?**
Fix an incorrect class name in the onboarding fragment, and re-hide the 'Add a Library Later' option on the refactored onboarding screen.

**Why are we doing this? (w/ JIRA link if applicable)**
This prevents a crash on startup, and re-hides the  'Add a Library Later' option, which reappeared due to refactoring of splash and onboarding.

**How should this be tested? / Do these changes have associated tests?**
The app should no longer crash when starting, and the 'Add a Library Later' option should not appear.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
@ray-lee ran the RayBooks app.