### PR TITLE
Enable Adobe DRM

### DIFF
--- a/.ci-local/credentials.sh
+++ b/.ci-local/credentials.sh
@@ -15,14 +15,14 @@ info()
   echo "credentials-local.sh: info: $1" 1>&2
 }
 
-#if [ -z "${NYPL_NEXUS_USER}" ]
-#then
-#  fatal "NYPL_NEXUS_USER is not defined"
-#fi
-#if [ -z "${NYPL_NEXUS_PASSWORD}" ]
-#then
-#  fatal "NYPL_NEXUS_PASSWORD is not defined"
-#fi
+if [ -z "${LYRASIS_AWS_ACCESS_ID}" ]
+then
+  fatal "LYRASIS_AWS_ACCESS_ID is not defined"
+fi
+if [ -z "${LYRASIS_AWS_SECRET_KEY}" ]
+then
+  fatal "LYRASIS_AWS_SECRET_KEY is not defined"
+fi
 
 #------------------------------------------------------------------------
 # Copy credentials into place.
@@ -47,25 +47,18 @@ CREDENTIALS_PATH=$(realpath ".ci/credentials") ||
   fatal "could not resolve credentials path"
 
 SIMPLYE_CREDENTIALS="${CREDENTIALS_PATH}/Certificates/SimplyE/Android"
-#OPENEBOOKS_CREDENTIALS="${CREDENTIALS_PATH}/OpenEbooks/Android"
 
 if [ ! -d "${SIMPLYE_CREDENTIALS}" ]
 then
   fatal "${SIMPLYE_CREDENTIALS} does not exist, or is not a directory"
 fi
-#if [ ! -d "${OPENEBOOKS_CREDENTIALS}" ]
-#then
-#  fatal "${OPENEBOOKS_CREDENTIALS} does not exist, or is not a directory"
-#fi
-#
+
 cat >> "${HOME}/.gradle/gradle.properties" <<EOF
 org.librarysimplified.drm.enabled=true
 
-#org.librarysimplified.nexus.depend=true
-#org.librarysimplified.nexus.username=${NYPL_NEXUS_USER}
-#org.librarysimplified.nexus.password=${NYPL_NEXUS_PASSWORD}
+org.lyrasis.aws.access_key_id=${LYRASIS_AWS_ACCESS_ID}
+org.lyrasis.aws.secret_access_key=${LYRASIS_AWS_SECRET_KEY}
 
-#org.librarysimplified.app.assets.openebooks=${OPENEBOOKS_CREDENTIALS}
 org.librarysimplified.app.assets.raybooks=${SIMPLYE_CREDENTIALS}
 EOF
 

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,11 @@ ext {
 //        ^ required by 'org.librarysimplified.drm.enabled'\
 //      """.stripIndent())
 //  }
+
+  awsAccessKeyId =
+    project.property("org.lyrasis.aws.access_key_id")
+  awsSecretKey =
+    project.property("org.lyrasis.aws.secret_access_key")
 }
 
 subprojects { project ->
@@ -98,6 +103,30 @@ subprojects { project ->
           password nyplNexusPassword
         }
         url 'https://nexus.librarysimplified.org:8443/nexus/content/groups/external/'
+      }
+    }
+
+    maven {
+      name = "S3 Snapshots"
+      url = "s3://se-maven-repo/snapshots/"
+      credentials(AwsCredentials) {
+        accessKey = awsAccessKeyId
+        secretKey = awsSecretKey
+      }
+      mavenContent {
+        snapshotsOnly()
+      }
+    }
+
+    maven {
+      name = "S3 Releases"
+      url = "s3://se-maven-repo/releases/"
+      credentials(AwsCredentials) {
+        accessKey = awsAccessKeyId
+        secretKey = awsSecretKey
+      }
+      mavenContent {
+        releasesOnly()
       }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,46 +30,18 @@ plugins {
 }
 
 ext {
-  // Required for some dependencies only available from our private nexus
-  //
-  nyplNexusDepend =
-    project.findProperty('org.librarysimplified.nexus.depend') as Boolean
-  nyplNexusUsername =
-    project.findProperty('org.librarysimplified.nexus.username') ?: ''
-  nyplNexusPassword =
-    project.findProperty('org.librarysimplified.nexus.password') ?: ''
-
-  if (nyplNexusDepend && !nyplNexusUsername) {
-    throw new GradleException(
-      """\
-      'org.librarysimplified.nexus.username' is undefined!
-        ^ required by 'org.librarysimplified.nexus.depend'\
-      """.stripIndent())
-  }
-  if (nyplNexusDepend && !nyplNexusPassword) {
-    throw new GradleException(
-      """\
-      'org.librarysimplified.nexus.password' is undefined!
-        ^ required by 'org.librarysimplified.nexus.depend'\
-      """.stripIndent())
-  }
-
-  // Required by some projects to build with drm support
-  //
   nyplDrmEnabled =
     project.findProperty('org.librarysimplified.drm.enabled') as Boolean
-//  if (nyplDrmEnabled && !nyplNexusDepend) {
-//    throw new GradleException(
-//      """\
-//      'org.librarysimplified.nexus.depend' is undefined!
-//        ^ required by 'org.librarysimplified.drm.enabled'\
-//      """.stripIndent())
-//  }
 
-  awsAccessKeyId =
-    project.property("org.lyrasis.aws.access_key_id")
-  awsSecretKey =
-    project.property("org.lyrasis.aws.secret_access_key")
+  if (nyplDrmEnabled) {
+    awsAccessKeyId =
+      project.property("org.lyrasis.aws.access_key_id")
+    awsSecretKey =
+      project.property("org.lyrasis.aws.secret_access_key")
+  } else {
+    awsAccessKeyId = ""
+    awsSecretKey = ""
+  }
 }
 
 subprojects { project ->
@@ -96,37 +68,29 @@ subprojects { project ->
     mavenCentral()
     google()
 
-    if (nyplNexusDepend) {
+    if (nyplDrmEnabled) {
       maven {
-        credentials {
-          username nyplNexusUsername
-          password nyplNexusPassword
+        name = "S3 Snapshots"
+        url = "s3://se-maven-repo/snapshots/"
+        credentials(AwsCredentials) {
+          accessKey = awsAccessKeyId
+          secretKey = awsSecretKey
         }
-        url 'https://nexus.librarysimplified.org:8443/nexus/content/groups/external/'
+        mavenContent {
+          snapshotsOnly()
+        }
       }
-    }
 
-    maven {
-      name = "S3 Snapshots"
-      url = "s3://se-maven-repo/snapshots/"
-      credentials(AwsCredentials) {
-        accessKey = awsAccessKeyId
-        secretKey = awsSecretKey
-      }
-      mavenContent {
-        snapshotsOnly()
-      }
-    }
-
-    maven {
-      name = "S3 Releases"
-      url = "s3://se-maven-repo/releases/"
-      credentials(AwsCredentials) {
-        accessKey = awsAccessKeyId
-        secretKey = awsSecretKey
-      }
-      mavenContent {
-        releasesOnly()
+      maven {
+        name = "S3 Releases"
+        url = "s3://se-maven-repo/releases/"
+        credentials(AwsCredentials) {
+          accessKey = awsAccessKeyId
+          secretKey = awsSecretKey
+        }
+        mavenContent {
+          releasesOnly()
+        }
       }
     }
 

--- a/libraries.gradle
+++ b/libraries.gradle
@@ -49,7 +49,7 @@ ext.versions = [
   mockito_kotlin                : '2.2.0',
   moshi                         : '1.8.0',
   nypl_audiobook_api            : '6.3.0',
-  nypl_drm_adobe                : '1.2.2',
+  nypl_drm_adobe                : '1.2.3',
   nypl_drm_axis                 : '1.0.0-SNAPSHOT',
   nypl_drm_core                 : '1.2.2',
   nypl_findaway                 : '6.0.0',

--- a/simplified-app-raybooks/build.gradle
+++ b/simplified-app-raybooks/build.gradle
@@ -6,8 +6,8 @@ import org.librarysimplified.gradle.RequiredAssetsTask
 // Fail the build if these assets aren't present
 //
 def requiredFiles = [:]
-//requiredFiles["ReaderClientCert.sig"] =
-//  "280838a4cb5c2ca4a2c8cf14e93f8ff72dbc6046cf188b5e83cf830f5159ce1e"
+requiredFiles["ReaderClientCert.sig"] =
+  "29f5f58e8fa1694892f27c5bd825cbba4da0cfcc9d2367c5d8d89a0bae89e328"
 requiredFiles["secrets.conf"] =
   "9c211ae0d153c29b72baab3bfad9de6c5cecb6b39bcda8206d36a65aaca0db21"
 
@@ -36,15 +36,13 @@ dependencies {
   implementation project(":simplified-accounts-source-nyplregistry")
   implementation project(":simplified-analytics-circulation")
 //  implementation project(":simplified-crashlytics")
-  implementation project(":simplified-migration-from3master")
+//  implementation project(":simplified-migration-from3master")
 //  implementation libraries.firebase_analytics
 //  implementation libraries.firebase_crashlytics
   implementation libraries.nypl_drm_core
+  implementation libraries.nypl_drm_adobe
   implementation libraries.nypl_findaway
 //  implementation libraries.nypl_overdrive
 
-//  if (nyplNexusDepend) {
-//    implementation libraries.nypl_drm_adobe
-//  }
   annotationProcessor libraries.google_autovalue_processor
 }

--- a/simplified-app-raybooks/src/main/res/values/features.xml
+++ b/simplified-app-raybooks/src/main/res/values/features.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!-- Build-time feature flags. -->
+<resources>
+  <string name="featureAdobeDRMPackageOverride" translatable="false">Raybooks</string>
+</resources>


### PR DESCRIPTION
**What's this do?**
This enables Adobe DRM by doing the following:

  * Repository declarations are declared for the
    S3 bucket that contains private Adobe binaries.

  * The name passed to the DRM connector is overridden
    to match that of our certificate.

  * A dependency on the Adobe DRM module is added to
    RayBooks.

  * The 3-Master migration is removed. It interacts
    with the Adobe DRM and there are no circumstances
    where a Lyrasis patron could ever have cause to
    run the migration.

**Why are we doing this? (w/ JIRA link if applicable)**
https://www.notion.so/lyrasis/Enable-DRM-in-Android-app-fc5d22d6bca24779b66c10a24cc3ff84

**How should this be tested? / Do these changes have associated tests?**
Try using the app with protected books.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
Information on how the S3 bucket works is about to be added to Notion.

**Did someone actually run this code to verify it works?**
@io7m logged in on a LYRASIS account.