### PR TITLE
Enable crashlytics.

### DIFF
--- a/simplified-app-raybooks/build.gradle
+++ b/simplified-app-raybooks/build.gradle
@@ -1,7 +1,7 @@
 import org.librarysimplified.gradle.RequiredAssetsTask
 
-//apply plugin: 'com.google.gms.google-services'
-//apply plugin: 'com.google.firebase.crashlytics'
+apply plugin: 'com.google.gms.google-services'
+apply plugin: 'com.google.firebase.crashlytics'
 
 // Fail the build if these assets aren't present
 //
@@ -35,10 +35,10 @@ dependencies {
   implementation project(":simplified-main")
   implementation project(":simplified-accounts-source-nyplregistry")
   implementation project(":simplified-analytics-circulation")
-//  implementation project(":simplified-crashlytics")
+  implementation project(":simplified-crashlytics")
 //  implementation project(":simplified-migration-from3master")
-//  implementation libraries.firebase_analytics
-//  implementation libraries.firebase_crashlytics
+  implementation libraries.firebase_analytics
+  implementation libraries.firebase_crashlytics
   implementation libraries.nypl_drm_core
   implementation libraries.nypl_drm_adobe
   implementation libraries.nypl_findaway

--- a/simplified-app-raybooks/google-services.json
+++ b/simplified-app-raybooks/google-services.json
@@ -1,0 +1,47 @@
+{
+  "project_info": {
+    "project_number": "287525833402",
+    "firebase_url": "https://raybooks-1ef32-default-rtdb.firebaseio.com",
+    "project_id": "raybooks-1ef32",
+    "storage_bucket": "raybooks-1ef32.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:287525833402:android:06fdf81f003d8a1c9bd083",
+        "android_client_info": {
+          "package_name": "org.lyrasis.raybooks"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "287525833402-9g3mbpq7bb68hhhalvntl9v7httiatru.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDK69dMWpbJ0VwU2WHKVnnJHqe0igbORtY"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "287525833402-9g3mbpq7bb68hhhalvntl9v7httiatru.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "287525833402-5jl0eaclkq82op1krg85c9esk6jl9je1.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "org.lyrasis.raybooks"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}


### PR DESCRIPTION
**What's this do?**

Enable crashlytics.

**Why are we doing this? (w/ JIRA link if applicable)**

This allows us to track app crashes in Firebase.

**How should this be tested? / Do these changes have associated tests?**

In the debug options screen, tap the Crash button. This should cause new crash information to be posted to the Crashlytics console in the RayBooks Firebase project: https://console.firebase.google.com/u/1/project/raybooks-1ef32/crashlytics/app/android:org.lyrasis.raybooks/issues?state=open&time=last-seven-days&type=crash 

**Dependencies for merging? Releasing to production?**

n/a

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran the RayBooks app.